### PR TITLE
Fix event creation way in poll test app

### DIFF
--- a/poll/tests.py
+++ b/poll/tests.py
@@ -35,14 +35,16 @@ def category_location1():
 
 @pytest.fixture
 def poll1(category_location1):
-    event = Event.objects.create(category=category_location1.category,
-                                 location=category_location1.location,
-                                 poll=None,
-                                 name=EVENT_NAME,
-                                 max_participants=MAX_PART,
-                                 start_time=DATETIME + timedelta(days=2),
-                                 end_time=DATETIME + timedelta(days=3),
-                                 is_private=IS_PRIVATE,)
+    event = Event(
+        category=category_location1.category,
+        location=category_location1.location,
+        poll=None,
+        name=EVENT_NAME,
+        max_participants=MAX_PART,
+        start_time=DATETIME + timedelta(days=2),
+        end_time=DATETIME + timedelta(days=3),
+        is_private=IS_PRIVATE,
+    )
     event.save()
     poll = Poll.objects.create(event_id=event, max_suggestions=5, end_time=get_default_end_date())
     poll.save()


### PR DESCRIPTION
### What this PR does?

Fix the way event model is been created in the poll test fixture to the directed way instead via the manager object

### Notes for reviewer


### Related Issue

Resolves #77 

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation