### PR TITLE
Add category migrations

### DIFF
--- a/category/migrations/0002_static_data.py
+++ b/category/migrations/0002_static_data.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def create_initial_categories(apps, schema_editor):
+    Category = apps.get_model('category', 'Category')
+    Category.objects.create(name='Soccer')
+    Category.objects.create(name='Football')
+    Category.objects.create(name='Basketball')
+    Category.objects.create(name='Baseball')
+    Category.objects.create(name='Gym')
+    Category.objects.create(name='Track and field')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('category', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_initial_categories),
+    ]

--- a/category/tests.py
+++ b/category/tests.py
@@ -57,3 +57,7 @@ class TestCategoryModel:
         category = Category.objects.create(name=valid_name)
         category.full_clean()
         assert category.name == valid_name
+
+    def test_static_category(self):
+        category = Category.objects.filter(name="Soccer").first()
+        assert category.name == "Soccer"

--- a/poll/tests.py
+++ b/poll/tests.py
@@ -8,7 +8,7 @@ from location.models import Location
 from category_location.models import CategoryLocation
 
 EVENT_NAME = "weight lifting"
-CATEGORY = "Gym"
+CATEGORY = "Gym1"
 LOCATION = "Holmes place Netanya"
 MAX_PART = 10
 IS_PRIVATE = False


### PR DESCRIPTION
Added migrations to have static categories for our app Also modified the poll tests, as the 'Gym' category already exists, and because of that some of the poll tests would otherwise fail because of the unique constrait

### What this PR does?

*Please describe the desired outcome for this PR.  Said another way, what was
the original request that resulted in these code changes?*

### Notes for reviewer

Added migrations for the category model
Modified the poll tests because of the unique constraint of the category model.

### Related Issue

Resolves #84

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation