### PR TITLE
Add join and leave functionality to event info page

### DIFF
--- a/event/migrations/0002_userevent.py
+++ b/event/migrations/0002_userevent.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('users', '0001_initial'),
         ('teams', '0001_initial'),
@@ -22,5 +21,9 @@ class Migration(migrations.Migration):
                 ('teamID', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='teams.teams')),
                 ('userID', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='users.profile')),
             ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='userevent',
+            unique_together={('userID', 'eventID')},
         ),
     ]

--- a/event/templates/event/event_info.html
+++ b/event/templates/event/event_info.html
@@ -1,7 +1,18 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="event-info-header">
-    <h2>{{event.name}} Event</h2>
+    <h2 id="title">{{event.name}} Event</h2>
+    {%if is_joined %}
+        <button id="join-leave-btn">
+            <a href="{% url 'view_event' user_id=user.id %}?id={{ event.id }}&join=0">Leave</a>
+        </button>
+    {%else %}
+        {% if event.participants_num < event.max_participants %} 
+            <button id="join-leave-btn">
+                <a href="{% url 'view_event' user_id=user.id %}?id={{ event.id }}&join=1">Join</a>
+            </button>
+        {% endif %}
+    {% endif %}
 </div>
 <div class="event-info-container">
     <ul>
@@ -11,7 +22,11 @@
         <li>Ends At: {{event.end_time}}</li>
         <li>Participants : {{event.participants_num}}/{{event.max_participants}}</li>
     </ul>
+    {% if event.participants_num == event.max_participants %} 
+        <p>This event is full</p>
+    {% endif %}
 </div>
+
 {% if event.participants_num > 1 %}
     {% if team1|length == 0 %}
         <form id="event-form" method="post" >

--- a/event/tests/conftest.py
+++ b/event/tests/conftest.py
@@ -195,6 +195,12 @@ def create_url(base_url):
 
 
 @pytest.fixture
+def first_event_info_url(base_url):
+    event = models.Event.manager.first()
+    return f'{base_url}info/?id={event.id}'
+
+
+@pytest.fixture
 def create_event_form_data1(category_location1):
     return {
         'name': EVENT_NAME,

--- a/event/tests/test_event.py
+++ b/event/tests/test_event.py
@@ -285,3 +285,22 @@ class TestEvent:
         location = models.Location.objects.filter(name="Bloomfield").first()
         assert event.category == category
         assert event.location == location
+
+    def test_leave_event(self, validate_event1, user1):
+        models.Event.manager.leave_event(user_id=user1.id, event_id=validate_event1.id)
+        users_in_event = models.UserEvent.objects.filter(eventID=validate_event1.id).values_list("userID", flat=True)
+        assert user1 not in users_in_event
+
+    @pytest.mark.parametrize(
+        "participants_current_num, max_participants_num, result",
+        [
+            (2, 2, True),
+            (1, 3, False),
+            (4, 3, True),
+        ],
+    )
+    def test_is_event_full(self, participants_current_num, max_participants_num, result, validate_event1):
+        validate_event1.participants_num = participants_current_num
+        validate_event1.max_participants = max_participants_num
+        validate_event1.save()
+        assert validate_event1.is_full() == result

--- a/event/tests/test_event_ui.py
+++ b/event/tests/test_event_ui.py
@@ -1,10 +1,12 @@
 import re
+import pytest
 from django.utils import timezone
 from pytest_django.asserts import assertRedirects
 from ..forms import EventForm
 from .. import models
 
 
+@pytest.mark.django_db()
 class TestEventUi:
     def test_create_event_get_method(self, client, create_url):
         response = client.get(create_url)
@@ -32,3 +34,7 @@ class TestEventUi:
         response = client.post(create_url, data=create_event_form_data1)
         assert response.status_code == 409
         assert models.EventManager.invalid_time_error_message == response.context['error']
+
+    def test_event_info(self, client, first_event_info_url):
+        response = client.get(first_event_info_url)
+        assert response.status_code == 200

--- a/event/tests/test_user_event.py
+++ b/event/tests/test_user_event.py
@@ -58,3 +58,16 @@ class TestUserEventModel:
         user_event.delete()
         with pytest.raises(UserEvent.DoesNotExist):
             UserEvent.objects.get(pk=create_user_event.pk)
+
+    def test_is_user_part_of_event_method_belong(self, validate_event1, user1):
+        assert UserEvent.is_user_part_of_event(user_id=user1.id, event_id=validate_event1.id)
+
+    def test_is_user_part_of_event_method_not_belong(self, validate_event1, user2):
+        assert not UserEvent.is_user_part_of_event(user_id=user2.id, event_id=validate_event1.id)
+
+    def test_user_event_custom_deletion(self, create_user_event):
+        user_id = create_user_event.userID.id
+        evnet_id = create_user_event.eventID.id
+        UserEvent.delete_entry(user_id=user_id, event_id=evnet_id)
+        all_entries = UserEvent.objects.all()
+        assert create_user_event not in all_entries

--- a/static_home_page/static/web_page_css.css
+++ b/static_home_page/static/web_page_css.css
@@ -141,8 +141,8 @@ p {
 
 .EventCont {
   margin: 3%;
-  display:'flex';
-  flex-direction:'column'
+  display: 'flex';
+  flex-direction: 'column'
 }
 
 .EventCont>* {
@@ -154,9 +154,10 @@ p {
   justify-content: space-around;
 }
 
-.EventsDetails-right{
+.EventsDetails-right {
   padding: 5% 0%;
 }
+
 .EventsDetails-left {
   padding: 5% 0%;
 }
@@ -189,7 +190,7 @@ p {
   border: none;
 }
 
-.EventButton > a {
+.EventButton>a {
   text-decoration: none;
   color: white;
 }
@@ -198,10 +199,12 @@ p {
   0% {
     transform: translateX(0px);
   }
-  50%{
+
+  50% {
     transform: translateX(-30px);
   }
-  100%{
+
+  100% {
     transform: translateX(0px);
 
   }
@@ -215,7 +218,8 @@ p {
   font-family: 'Poppins'
 }
 
-.form-select, .form-button {
+.form-select,
+.form-button {
   padding: 0.5rem;
   margin-top: 0.5rem;
   border: 2px solid #e9bc52;
@@ -288,13 +292,38 @@ p {
 }
 
 .event-info-header {
-  margin: 15px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.event-info-header #title {
+  text-align: center;
+  flex-grow: 1;
+}
+
+.event-info-header #join-leave-btn {
+  margin-left: auto;
+  margin-right: 50px;
+  width: 50px;
+}
+
+.event-info-header #join-leave-btn>a {
+  text-decoration: none;
+  color: black;
 }
 
 .event-info-container {
   margin: 20px;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+}
+
+.event-info-container>p {
+  margin-top: 10px;
+  font-size: 16px;
+  color: Red;
 }
 
 .event-info-container>ul>li {
@@ -305,24 +334,24 @@ p {
 table {
   width: 750px;
   border-collapse: collapse;
-  margin:50px auto;
-  }
+  margin: 50px auto;
+}
 
 /* Zebra striping */
 tr:nth-of-type(odd) {
   background: #eee;
-  }
+}
 
 th {
   background: #3498db;
   color: white;
   font-weight: bold;
-  }
+}
 
-td, th {
+td,
+th {
   padding: 10px;
   border: 1px solid #ccc;
   text-align: left;
   font-size: 18px;
-  }
-
+}


### PR DESCRIPTION
### What this PR does?
This adds to the event info page the option to leave or join the event according to the user's current state regarding to the event.

This adds:
- Event model the leave and validator function
- User event model the check if a user is part of an event
- Button to the info HTML
- Data field in the view context that says if the user is part of the event or not
- Constrain that a combination of user-id and event id in the user event table must be unique to avoid duplication in this table

Relevant test were added

### Notes for reviewer
Page when user can join the event (Has a "join" button)
![image](https://github.com/redhat-beyond/FitMeet/assets/96543255/4b3cab57-3a96-41ca-8a5d-1012c62792db)

After user joined the event a "leave" button will be presented 
![image](https://github.com/redhat-beyond/FitMeet/assets/96543255/93451649-d669-477b-bb84-e6687df0724e)

When a user that is not part of the event visits the page and the event is full. No button will be presented and a message that the event is full will be presented
![image](https://github.com/redhat-beyond/FitMeet/assets/96543255/820f3e1f-63ab-4911-8f8e-7a443e66cf6f)


### Related Issue

Resolves #126 

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation